### PR TITLE
enhancing doCopy function

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -56,8 +56,13 @@ def getActiveProfile():
 	return activeProfile
 
 def doCopy(copyDirectory):
+	# to ensure that the removed directory will not be one of the main directories such as documents or music or other important ones
+	if not os.path.basename(copyDirectory)== "personalFeeds":
+		copyDirectory=os.path.join(copyDirectory, "personalFeeds")
 	try:
-		shutil.rmtree(copyDirectory, ignore_errors=True)
+		if os.path.exists(copyDirectory):
+			#if it exists, only personalFeeds folder will be remove, which is the base name of copyDirectory path
+			shutil.rmtree(copyDirectory, ignore_errors=True)
 		shutil.copytree(FEEDS_PATH, copyDirectory)
 		core.callLater(100, ui.message,
 			# Translators: Message presented when feeds have been copied.


### PR DESCRIPTION
hello
using the addon and trying to copy read feeds folder
if we select the folder to ccopy the feeds to it, say any important folder documents or usb drive for instance
this selected folder will be deleted with it's content, before copying the reedFeed files to new one of the same name.
and I think this is not wanted, especially if the folder selected was important like documents or music or any important folder to us.
because of this I have added to doCopy function few lines to avoid that, and made the pull request on it.
feel free to ignore if you find it not good, or modify or any thing you see it appropriate
I appreciate much your efforts and contribution to the community.
regards.
ibrahim.
