### PR TITLE
Add button to copy feed address

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -310,7 +310,7 @@ class FeedsDialog(wx.Dialog):
 			_("Do you want to copy feed address to the clipboard\r\n\r\n{feedAddress}?".format(address)),
 			# Translators: the title of a message box dialog.
 			_("Copy feed address"),
-			wx.YES|wx.NO|wx.CANCEL|wx.ICON_QUESTION
+			wx.YES | wx.NO | wx.CANCEL | wx.ICON_QUESTION
 		) == wx.YES:
 			api.copyToClip(address)
 

--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -307,7 +307,7 @@ class FeedsDialog(wx.Dialog):
 			address = f.read()
 		if gui.messageBox(
 			# Translators: the label of a message box dialog.
-			_("Do you want to copy feed address to the clipboard\r\n\r\n{feedAddress}?".format(address)),
+			_("Do you want to copy feed address to the clipboard\r\n\r\n{feedAddress}?".format(feedAddress=address)),
 			# Translators: the title of a message box dialog.
 			_("Copy feed address"),
 			wx.YES | wx.NO | wx.CANCEL | wx.ICON_QUESTION

--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -171,6 +171,10 @@ class FeedsDialog(wx.Dialog):
 		self.openHtmlButton = buttonHelper.addButton(self, label=_("Open feed as &HTML"))
 		self.openHtmlButton.Bind(wx.EVT_BUTTON, self.onOpenHtml)
 
+		# Translators: The label of a button to copy the feed URL.
+		self.copyButton = buttonHelper.addButton(self, label=_("Cop&y feed address"))
+		self.copyButton.Bind(wx.EVT_BUTTON, self.onCopy)
+
 		# Translators: The label of a button to add a new feed.
 		newButton = buttonHelper.addButton(self, label=_("&New..."))
 		newButton.Bind(wx.EVT_BUTTON, self.onNew)
@@ -297,6 +301,18 @@ class FeedsDialog(wx.Dialog):
 		self.feed = Feed(address)
 		self.feed.buildHtml()
 		os.startfile(os.path.join(HTML_PATH, "feed.html"))
+
+	def onCopy(self, evt):
+		with open(os.path.join(FEEDS_PATH, "%s.txt" % self.stringSel), "r", encoding="utf-8") as f:
+			address = f.read()
+		if gui.messageBox(
+			# Translators: the label of a message box dialog.
+			_("Do you want to copy feed address to the clipboard\r\n\r\n{feedAddress}?".format(address)),
+			# Translators: the title of a message box dialog.
+			_("Copy feed address"),
+			wx.YES|wx.NO|wx.CANCEL|wx.ICON_QUESTION
+		) == wx.YES:
+			api.copyToClip(address)
 
 	def onNew(self, evt):
 		# Translators: The label of a field to enter an address for a new feed.

--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("""Add-on for using NVDA as a feed reader."""),
 	# version
-	"addon_version" : "10.11-dev",
+	"addon_version" : "10.12-dev",
 	# Author(s)
 	"addon_author" : u"Noelia Ruiz Martínez <nrm1977@gmail.com>, Mesar Hameed <mhameed@src.gnome.org>",
 	# URL for the add-on documentation support

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 * Download [stable version][1]
 * Download [development version][2]
 
-This addon provides a straightforward  way to read feeds in Atom or RSS formats using NVDA.
+This addon provides a straightforward way to read feeds in Atom or RSS formats using NVDA.
 The feeds will not be refreshed automatically.
 Below when we mention feeds, we mean both RSS and ATOM feeds.
 
@@ -30,6 +30,7 @@ Opens a dialog with the following controls:
 * List of articles: Opens a dialog which presents the articles list from your current feed. Select the article you want to read and press Enter or Open web page of selected article button to open the corresponding page in your browser. Press About article button to open a dialog showing title and link of the selected article; from this dialog, you'll be able to copy this info to the clipboard.
 * Open feed: Opens the selected feed in the default application.
 * Open feed as HTML: Opens the selected feed in the default web browser. You will be able to show or hide publication dates and buttons to copy information about articles to clipboard.
+* Copy feed address: Opens a dialog to confirm if you want to copy the feed address to clipboard.
 * New: Opens a dialog with an edit box to enter the address of a new feed. If the address is valid and the feed can be saved, its name, based on the feed title, will appear at the bottom of the feeds list.
 * Rename: Opens a dialog with an edit box to rename the selected feed.
 * Delete: Opens a dialog to delete the selected feed after confirmation.
@@ -75,6 +76,7 @@ Opens a dialog to select a folder which replaces your feeds in the personalFeeds
 * More feeds may be supported.
 * When the feeds dialog is opened, the list of feeds will be focused instead of the search edit box.
 * You can choose if the search edit box is placed after the list of feeds, useful to focus the list event when switching from another window without closing the Feeds dialog.
+* Added a button to copy the feed address to clipboard from the feeds dialog.
 
 ## Changes for 9.0 ##
 


### PR DESCRIPTION
## Link to issue number:

Fixes issue #11 

### Summary of the issue:

Possibility of copying feed address to clipboard from feed dialog can be useful to share.

### Description of how this pull request fixes the issue:

A button to copy the URL of the selected feed has been added to the feeds dialog, similar to the button to copy info about articles.

### Testing performed:

Tested the button to copy articles, similar to this.

### Known issues with pull request:

None

### Change log entry:

* Added a button to copy the feed address to clipboard from the feeds dialog.