### PR TITLE
Version 10.0.1

### DIFF
--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 
 # installTasks for the readFeeds add-on
-# Copyright (C) 2013-2019 Noelia Ruiz Martínez, other contributors
+# Copyright (C) 2013-2020 Noelia Ruiz Martínez, other contributors
 # Released under GPL2
 
 import addonHandler
@@ -9,7 +9,6 @@ import globalVars
 import os
 import shutil
 import glob
-import gui
 import wx
 
 ADDON_DIR = os.path.abspath(os.path.dirname(__file__))
@@ -20,6 +19,7 @@ addonHandler.initTranslation()
 
 
 def onInstall():
+	import gui
 	addonPath = [os.path.join(CONFIG_PATH, "RSS"), os.path.join(CONFIG_PATH, "personalFeeds")]
 	for path in addonPath:
 		if not os.path.isdir(path):

--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("""Add-on for using NVDA as a feed reader."""),
 	# version
-	"addon_version" : "10.1-dev",
+	"addon_version" : "10.0.1-dev",
 	# Author(s)
 	"addon_author" : u"Noelia Ruiz Martínez <nrm1977@gmail.com>, Mesar Hameed <mhameed@src.gnome.org>",
 	# URL for the add-on documentation support

--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("""Add-on for using NVDA as a feed reader."""),
 	# version
-	"addon_version" : "10.0",
+	"addon_version" : "10.1-dev",
 	# Author(s)
 	"addon_author" : u"Noelia Ruiz Martínez <nrm1977@gmail.com>, Mesar Hameed <mhameed@src.gnome.org>",
 	# URL for the add-on documentation support
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion" : "2019.3",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2020.3",
+	"addon_lastTestedNVDAVersion" : "2020.4",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel" : None,
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,3 @@
-## Changes for 10.0 ##
+## Changes for 10.0.1 ##
 
-* Added a button to open the selected feed as HTML in the default web browser.
-* If a new feed cannot be created, this will be notified in an error dialog.
-* Improved order and presentation of some articles.
-* More feeds may be supported.
-* When the feeds dialog is opened, the list of feeds will be focused instead of the search edit box.
-* You can choose if the search edit box is placed after the list of feeds, useful to focus the list event when switching from another window without closing the Feeds dialog.
-* Added a button to copy the feed address to clipboard from the feeds dialog.
+* Compatible with NVDA 2020.4beta1.


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Gui needs to be imported at the onInstall() method level in installTasks to avoid a crash in NVDA 2020.4beta1.
### Description of how this pull request fixes the issue:
Move import gui from installTasks at level module to onInstall() method.
### Testing performed:
Tested add-ons like placeMarkers, reportPasswords and emoticons.
### Known issues with pull request:
None
### Change log entry:
None