### PR TITLE
Fix installation

### DIFF
--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 
 # installTasks for the readFeeds add-on
-# Copyright (C) 2013-2019 Noelia Ruiz Martínez, other contributors
+# Copyright (C) 2013-2021 Noelia Ruiz Martínez, other contributors
 # Released under GPL2
 
 import addonHandler
@@ -21,38 +21,40 @@ addonHandler.initTranslation()
 
 def onInstall():
 	addonPath = [os.path.join(CONFIG_PATH, "RSS"), os.path.join(CONFIG_PATH, "personalFeeds")]
+	shouldOfferRestoreBackup = False
 	for path in addonPath:
 		if not os.path.isdir(path):
 			continue
 		pathFiles = os.listdir(path)
 		validFiles = glob.glob(path + "\\*.txt")
 		if len(pathFiles) != len(validFiles):
-			return
-	if gui.messageBox(
-		_(
-			# Translators: the label of a message box dialog.
-			"""Your configuration folder for NVDA contains files that seem to be derived
-			from a previous version of this add-on.
-			Do you want to update it?"""
-		),
-		# Translators: the title of a message box dialog.
-		_("Install or update add-on"),
-		wx.YES | wx.NO | wx.ICON_WARNING
-	) == wx.YES:
-		for file in validFiles:
-			try:
-				shutil.copy(file, FEEDS_PATH)
-			except IOError:
-				pass
-		return
-	previousFeedsPath = os.path.join(
-		CONFIG_PATH, "addons", "readFeeds",
-		"globalPlugins", "readFeeds", "personalFeeds"
-	)
-	if os.path.isdir(previousFeedsPath):
-		validFiles = glob.glob(previousFeedsPath + "\\*.txt")
-		for file in validFiles:
-			try:
-				shutil.copy(file, FEEDS_PATH)
-			except IOError:
-				pass
+			continue
+		shouldOfferRestoreBackup = True
+	if shouldOfferRestoreBackup:
+		if gui.messageBox(
+			_(
+				# Translators: the label of a message box dialog.
+				"""Your configuration folder for NVDA contains files that seem to be derived
+				from a previous version of this add-on.
+				Do you want to update it?"""
+			),
+			# Translators: the title of a message box dialog.
+			_("Install or update add-on"),
+			wx.YES | wx.NO | wx.ICON_WARNING) == wx.YES:
+			for file in validFiles:
+				try:
+					shutil.copy(file, FEEDS_PATH)
+				except IOError:
+					pass
+	else:
+		previousFeedsPath = os.path.join(
+			CONFIG_PATH, "addons", "readFeeds",
+			"globalPlugins", "readFeeds", "personalFeeds"
+		)
+		if os.path.isdir(previousFeedsPath):
+			validFiles = glob.glob(previousFeedsPath + "\\*.txt")
+			for file in validFiles:
+				try:
+					shutil.copy(file, FEEDS_PATH)
+				except IOError:
+					pass


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Sumarized by @Christianlm in 

https://nvda-addons.groups.io/g/nvda-addons/message/15625

1. Remove personalFeeds folder from your user config directory (if any).
2. try install or update readFeed.

A confirmation dialog  appears to import the previous files, even if I manually deleted them first.
The expected behavior is that it shouldn't ask for confirmation since there are no saved feeds.

Thanks also other contributors in the same topic).

### Description of how this pull request fixes the issue:
Created a shouldOfferRestoreBackup variable to determine if the message box to restore feeds saved in personalFeeds or RSS subfolders, under config path, should be presented.

### Testing performed:
None yet.
### Known issues with pull request:
None
### Change log entry:
To be determined.