### PR TITLE
Use format instead of f-string in translatable message

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -133,7 +133,7 @@ class FeedsDialog(wx.Dialog):
 		addressFile = config.conf["readFeeds"]["addressFile"]
 		super(FeedsDialog, self).__init__(
 			# Translators: Title of a dialog.
-			parent, title=_(f"Feeds: {addressFile} ({getActiveProfile()})")
+			parent, title=_("Feeds: {file} ({profile})".format(file=addressFile, profile=getActiveProfile()))
 		)
 
 		mainSizer = wx.BoxSizer(wx.VERTICAL)


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
Fixes issue #18 
### Summary of the issue:
Gettext doesn't support f-string, so a message is not translated.
### Description of how this pull request fixes the issue:
Replace f-string with format syntax.
### Testing performed:
Check that spanish .po file is right but f-string message is not translated.
### Known issues with pull request:
None
### Change log entry:
Fixed translatable string