### PR TITLE
Fix NVDA's shortcuts

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -826,7 +826,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self.menu = gui.mainFrame.sysTrayIcon.toolsMenu
 		self.readFeedsMenu = wx.Menu()
 		# Translators: the name of a submenu.
-		self.mainItem = self.menu.AppendSubMenu(self.readFeedsMenu, _("&Read Feeds"))
+		self.mainItem = self.menu.AppendSubMenu(self.readFeedsMenu, _("Read Feeds"))
 		# Translators: the name of a menu item.
 		self.feedsListItem = self.readFeedsMenu.Append(wx.ID_ANY, _("&Feeds..."))
 		gui.mainFrame.sysTrayIcon.Bind(wx.EVT_MENU, self.onFeeds, self.feedsListItem)


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
Fixes issue #20

### Summary of the issue:
The readFeeds submenu under tools removes shortcuts for items contained in the Tools menu.
### Description of how this pull request fixes the issue:
Remove ampersand (&) of Read feeds submenu.
### Testing performed:
Tested locally with NVDA set to English.
### Known issues with pull request:
None
### Change log entry:
* Fixed a bug which made shortcuts for items of NVDA's tools menu don't work as expected.