### PR TITLE
Opml

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -351,7 +351,6 @@ class FeedsDialog(wx.Dialog):
 		self._opml._document.getroot().find("body").remove(element)
 		self._opml._document.write(OPML_PATH)
 		self.feedsList.Delete(self.sel)
-		self.feedsList.Selection = 0
 		self.onFeedsListChoice(None)
 		self.feedsList.SetFocus()
 
@@ -408,6 +407,10 @@ class FeedsDialog(wx.Dialog):
 			body.remove(outline)
 			body.append(outline)
 		self._opml._document.write(OPML_PATH)
+		self.feedsList.Clear()
+		for outline in outlines:
+			self.feedsList.Append(outline.get("title"))
+		self.feedsList.Selection = 0
 		self.feedsList.SetFocus()
 
 

--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 
 # Read feeds: A simple plugin for reading feeds with NVDA
-# Copyright (C) 2012-2020 Noelia Ruiz Martínez, Mesar Hameed
+# Copyright (C) 2012-2021 Noelia Ruiz Martínez, Mesar Hameed
 # Released under GPL 2
 
 import os
@@ -36,7 +36,7 @@ addonHandler.initTranslation()
 ADDON_SUMMARY = addonHandler.getCodeAddon().manifest['summary']
 ADDON_PANEL_TITLE = ADDON_SUMMARY
 FEEDS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "personalFeeds"))
-OPML_PATH = FEEDS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), FEEDS_PATH, "readFeeds.opml"))
+OPML_PATH = os.path.join(FEEDS_PATH, "readFeeds.opml")
 HTML_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "html"))
 CONFIG_PATH = globalVars.appArgs.configPath
 DEFAULT_ADDRESS_FILE = "addressFile"
@@ -409,7 +409,6 @@ class FeedsDialog(wx.Dialog):
 			body.append(outline)
 		self._opml._document.write(OPML_PATH)
 		self.feedsList.SetFocus()
-
 
 
 class ArticlesDialog(wx.Dialog):
@@ -904,6 +903,7 @@ class Opml(object):
 			body.append(outline)
 
 		self._document.write(self._path)
+
 
 # Global plugin
 

--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -886,14 +886,6 @@ class Opml(object):
 			return True
 		return False
 
-	def opmlToTextFiles(self, pth):
-		for outline in self._document.getroot().iter("outline"):
-			title = outline.get("title")
-			url = outline.get("xmlUrl")
-			filename = api.filterFileName(title.strip())
-			with open(path, "w", encoding="utf-8") as f:
-				f.write(url)
-
 	def addFeed(self, title, url):
 		element = ElementTree.Element("outline")
 		element.set("title", title)

--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -397,7 +397,7 @@ class FeedsDialog(wx.Dialog):
 			# Translators: Label for a file dialog.
 			self, _("Open OPML file"),
 			# Translators: Wildcards for a file dialog
-			wildcard=_("OPML files (*.xyz)|*.opml"),
+			wildcard=_("OPML files (*.opml; *.xml)|*.opml; *.xml"),
 			style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST
 		) as fileDialog:
 			if fileDialog.ShowModal() == wx.ID_CANCEL:
@@ -405,6 +405,7 @@ class FeedsDialog(wx.Dialog):
 			pathname = fileDialog.GetPath()
 		opml = Opml(pathname)
 		opml.opmlToTextFiles()
+		#log.info("done")
 
 
 class ArticlesDialog(wx.Dialog):
@@ -878,7 +879,8 @@ class Opml(object):
 		return False
 
 	def opmlToTextFiles(self):
-		for outline in self._document.getroot().findall("outline"):
+		body = self._document.getroot().find("body")
+		for outline in body.findall("outline"):
 			title = outline.get("title")
 			url = outline.get("xmlUrl")
 			filename = api.filterFileName(title.strip())

--- a/addon/globalPlugins/readFeeds/personalFeeds/W3C-news.txt
+++ b/addon/globalPlugins/readFeeds/personalFeeds/W3C-news.txt
@@ -1,1 +1,0 @@
-http://www.w3.org/News/atom.xml

--- a/addon/globalPlugins/readFeeds/personalFeeds/addons NVDA-project IT RSS.txt
+++ b/addon/globalPlugins/readFeeds/personalFeeds/addons NVDA-project IT RSS.txt
@@ -1,1 +1,0 @@
-http://addons.nvda-project.org/index.it.rss

--- a/addon/globalPlugins/readFeeds/personalFeeds/addressFile.txt
+++ b/addon/globalPlugins/readFeeds/personalFeeds/addressFile.txt
@@ -1,1 +1,0 @@
-http://www.gutenberg.org/cache/epub/feeds/today.rss

--- a/addon/globalPlugins/readFeeds/personalFeeds/readFeeds.opml
+++ b/addon/globalPlugins/readFeeds/personalFeeds/readFeeds.opml
@@ -1,0 +1,23 @@
+<opml version="2.0">
+  <head>
+    <title>readFeeds</title>
+  </head>
+  <body>
+    <outline text="Astronomy Picture of the Day" title="Astronomy Picture of the Day" xmlUrl="http://www.jwz.org/cheesegrater/RSS/apod.rss" />
+<outline title="Benvenuto sul sito web della comunit&#224; componenti aggiuntivi di NVDA" xmlUrl="http://addons.nvda-project.org/index.it.rss" /><outline text="NVDA" title="NVDA" xmlUrl="https://nvda.groups.io/g/nvda/rss" />
+<outline text="NVDA" title="NVDA" xmlUrl="https://nvda.groups.io/g/nvda/rss" />
+<outline text="Olli's blog" title="Olli's blog" xmlUrl="http://my.opera.com/olli/xml/atom/blog/" />
+<outline text="Olli's blog" title="Olli's blog" xmlUrl="http://my.opera.com/olli/xml/atom/blog/" />
+<outline text="Science in Action" title="Science in Action" xmlUrl="https://podcasts.files.bbci.co.uk/p002vsnb.rss" />
+<outline text="Science in Action" title="Science in Action" xmlUrl="https://podcasts.files.bbci.co.uk/p002vsnb.rss" />
+<outline text="UserJS" title="UserJS" xmlUrl="http://userjs.org/subscribe/news" />
+<outline text="UserJS" title="UserJS" xmlUrl="http://userjs.org/subscribe/news" />
+<outline text="W3C-news" title="W3C-news" xmlUrl="http://www.w3.org/News/atom.xml" />
+<outline text="W3C-news" title="W3C-news" xmlUrl="http://www.w3.org/News/atom.xml" />
+<outline text="addons NVDA-project IT RSS" title="addons NVDA-project IT RSS" xmlUrl="http://addons.nvda-project.org/index.it.rss" />
+<outline text="addons NVDA-project IT RSS" title="addons NVDA-project IT RSS" xmlUrl="http://addons.nvda-project.org/index.it.rss" />
+<outline text="addressFile" title="addressFile" xmlUrl="http://www.gutenberg.org/cache/epub/feeds/today.rss" />
+<outline text="addressFile" title="addressFile" xmlUrl="http://www.gutenberg.org/cache/epub/feeds/today.rss" />
+<outline title="maria" xmlUrl="http://www.gutenberg.org/cache/epub/feeds/today.rss" />
+  </body>
+</opml>

--- a/addon/globalPlugins/readFeeds/personalFeeds/readFeeds.opml
+++ b/addon/globalPlugins/readFeeds/personalFeeds/readFeeds.opml
@@ -3,21 +3,6 @@
     <title>readFeeds</title>
   </head>
   <body>
-    <outline text="Astronomy Picture of the Day" title="Astronomy Picture of the Day" xmlUrl="http://www.jwz.org/cheesegrater/RSS/apod.rss" />
-<outline title="Benvenuto sul sito web della comunit&#224; componenti aggiuntivi di NVDA" xmlUrl="http://addons.nvda-project.org/index.it.rss" /><outline text="NVDA" title="NVDA" xmlUrl="https://nvda.groups.io/g/nvda/rss" />
-<outline text="NVDA" title="NVDA" xmlUrl="https://nvda.groups.io/g/nvda/rss" />
-<outline text="Olli's blog" title="Olli's blog" xmlUrl="http://my.opera.com/olli/xml/atom/blog/" />
-<outline text="Olli's blog" title="Olli's blog" xmlUrl="http://my.opera.com/olli/xml/atom/blog/" />
-<outline text="Science in Action" title="Science in Action" xmlUrl="https://podcasts.files.bbci.co.uk/p002vsnb.rss" />
-<outline text="Science in Action" title="Science in Action" xmlUrl="https://podcasts.files.bbci.co.uk/p002vsnb.rss" />
-<outline text="UserJS" title="UserJS" xmlUrl="http://userjs.org/subscribe/news" />
-<outline text="UserJS" title="UserJS" xmlUrl="http://userjs.org/subscribe/news" />
-<outline text="W3C-news" title="W3C-news" xmlUrl="http://www.w3.org/News/atom.xml" />
-<outline text="W3C-news" title="W3C-news" xmlUrl="http://www.w3.org/News/atom.xml" />
-<outline text="addons NVDA-project IT RSS" title="addons NVDA-project IT RSS" xmlUrl="http://addons.nvda-project.org/index.it.rss" />
-<outline text="addons NVDA-project IT RSS" title="addons NVDA-project IT RSS" xmlUrl="http://addons.nvda-project.org/index.it.rss" />
-<outline text="addressFile" title="addressFile" xmlUrl="http://www.gutenberg.org/cache/epub/feeds/today.rss" />
-<outline text="addressFile" title="addressFile" xmlUrl="http://www.gutenberg.org/cache/epub/feeds/today.rss" />
-<outline title="maria" xmlUrl="http://www.gutenberg.org/cache/epub/feeds/today.rss" />
+  <outline text="Project Gutenberg" title="Project Gutenberg" xmlUrl="http://www.gutenberg.org/cache/epub/feeds/today.rss" />
   </body>
 </opml>

--- a/addon/globalPlugins/readFeeds/personalFeeds/readFeeds.opml
+++ b/addon/globalPlugins/readFeeds/personalFeeds/readFeeds.opml
@@ -1,8 +1,0 @@
-<opml version="2.0">
-  <head>
-    <title>readFeeds</title>
-  </head>
-  <body>
-  <outline text="Project Gutenberg" title="Project Gutenberg" xmlUrl="http://www.gutenberg.org/cache/epub/feeds/today.rss" />
-  </body>
-</opml>


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
Closes #22 
### Summary of the issue:
Add support for OPML files.
### Description of how this pull request fixes the issue:
Added a class for OPML management and modified the List of feeds dialog.
### Testing performed:
Tested locally:
- Create feed.
- Seen list of feeds and open list of articles.
- Rename feed.
- Delete feed.
- Import an OPML file.

### Known issues with pull request:
Text files will not be supported, so a feature to import them should be added.
### Change log entry:
* Feeds are managed from OPML files. Text files aren't longer supported.