### PR TITLE
Sort renamed feeds, reported privately

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -400,7 +400,12 @@ class FeedsDialog(wx.Dialog):
 			element = self._opml._document.getroot().findall(".body/outline")[self.sel]
 			element.set("title", newName)
 			element.set("text", newName)
-			self._opml._document.write(OPML_PATH)
+		body = self._opml._document.getroot().find("body")
+		outlines = sorted(body.findall("outline"), key=lambda el: el.get("title"))
+		for outline in outlines:
+			body.remove(outline)
+			body.append(outline)
+		self._opml._document.write(OPML_PATH)
 		self.feedsList.SetString(self.sel, newName)
 		self.feedsList.SetFocus()
 


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Renamed feeds aren't sorted (regression).
### Description of how this pull request fixes the issue:
Use sorted(outlines) before writing the .opml file, like done when importing feeds.
### Testing performed:
Tested locally.
### Known issues with pull request:
None.
### Change log entry:
None (regression).