### PR TITLE
Fix regression due to OPML support

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -178,11 +178,11 @@ class FeedsDialog(wx.Dialog):
 		feedsListGroupContents = wx.BoxSizer(wx.HORIZONTAL)
 		changeFeedsSizer = wx.BoxSizer(wx.VERTICAL)
 
-		body = self._opml._document.getroot().find("body")
-		outlines = sorted(body.findall("outline"), key=lambda el: el.get("title"))
+		self.body = self._opml._document.getroot().find("body")
+		outlines = sorted(self.body.findall("outline"), key=lambda el: el.get("title"))
 		for outline in outlines:
-			body.remove(outline)
-			body.append(outline)
+			self.body.remove(outline)
+			self.body.append(outline)
 		self._opml._document.write(OPML_PATH)
 		self.choices = [outline.get("title") for outline in self._opml._document.getroot().iter("outline")]
 		self.filteredItems = []
@@ -329,7 +329,7 @@ class FeedsDialog(wx.Dialog):
 		self.defaultButton.Enabled = self.sel >= 0
 
 	def onArticles(self, evt):
-		address = self._opml._document.getroot().findall("./body/outline")[self.filteredItems[self.sel]].get("xmlUrl")
+		address = self.body.findall("outline")[self.filteredItems[self.sel]].get("xmlUrl")
 		self.feed = Feed(address)
 		self.Disable()
 		try:
@@ -339,17 +339,17 @@ class FeedsDialog(wx.Dialog):
 			raise e
 
 	def onOpen(self, evt):
-		address = self._opml._document.getroot().findall("./body/outline")[self.filteredItems[self.sel]].get("xmlUrl")
+		address = self.body.findall("outline")[self.filteredItems[self.sel]].get("xmlUrl")
 		os.startfile(address)
 
 	def onOpenHtml(self, evt):
-		address = self._opml._document.getroot().findall("./body/outline")[self.filteredItems[self.sel]].get("xmlUrl")
+		address = self.body.findall("outline")[self.filteredItems[self.sel]].get("xmlUrl")
 		self.feed = Feed(address)
 		self.feed.buildHtml()
 		os.startfile(os.path.join(HTML_PATH, "feed.html"))
 
 	def onCopy(self, evt):
-		address = self._opml._document.getroot().findall("./body/outline")[self.filteredItems[self.sel]].get("xmlUrl")
+		address = self.body.findall("outline")[self.filteredItems[self.sel]].get("xmlUrl")
 		if gui.messageBox(
 			# Translators: the label of a message box dialog.
 			_("Do you want to copy feed address to the clipboard\r\n\r\n{feedAddress}?".format(feedAddress=address)),
@@ -373,9 +373,9 @@ class FeedsDialog(wx.Dialog):
 		name = self.createFeed(d.Value)
 		self.feedsList.Append(name)
 		self.choices.append(name)
-		newItem = self.filteredItems[-1] +1
+		newItem = self.filteredItems[-1] + 1
 		self.filteredItems.append(newItem)
-		self.feedsList.Selection = self.feedsList.Count -1
+		self.feedsList.Selection = self.feedsList.Count - 1
 		self.onFeedsListChoice(None)
 		self.feedsList.SetFocus()
 
@@ -389,9 +389,8 @@ class FeedsDialog(wx.Dialog):
 		) == wx.NO:
 			self.feedsList.SetFocus()
 			return
-		body = self._opml._document.getroot().find("body")
-		outline = self._opml._document.getroot().findall("./body/outline")[self.filteredItems[self.sel]]
-		body.remove(outline)
+		outline = self.body.findall("outline")[self.filteredItems[self.sel]]
+		self.body.remove(outline)
 		self._opml._document.write(OPML_PATH)
 		del self.choices[self.filteredItems[self.sel]]
 		self.filteredItems = []
@@ -402,12 +401,10 @@ class FeedsDialog(wx.Dialog):
 			self.filteredItems.append(n)
 		self.feedsList.Selection = 0
 		self.onFeedsListChoice(None)
-		from logHandler import log
-		log.info(f"selection: {self.sel}, string: {self.stringSel}, item: {self.filteredItems[self.sel]}")
 		self.feedsList.SetFocus()
 
 	def onDefault(self, evt):
-		url = self._opml._document.getroot().findall(".body/outline")[self.filteredItems[self.sel]].get("xmlUrl")
+		url = self.body.findall("outline")[self.filteredItems[self.sel]].get("xmlUrl")
 		config.conf["readFeeds"]["defaultUrl"] = url
 		self.onFeedsListChoice(None)
 		self.feedsList.SetFocus()
@@ -423,7 +420,7 @@ class FeedsDialog(wx.Dialog):
 				self.feedsList.SetFocus()
 				return
 			newName = d.Value
-			outline = self._opml._document.getroot().findall(".body/outline")[self.filteredItems[self.sel]]
+			outline = self.body.findall("outline")[self.filteredItems[self.sel]]
 			outline.set("title", newName)
 			outline.set("text", newName)
 		self._opml._document.write(OPML_PATH)
@@ -455,14 +452,13 @@ class FeedsDialog(wx.Dialog):
 			pathname = fileDialog.GetPath()
 		opml = Opml(pathname)
 		feeds = opml._document.getroot().findall("./body/outline")
-		body = self._opml._document.getroot().find("body")
 		for feed in feeds:
-			body.append(feed)
+			self.body.append(feed)
 		self._opml._document.write(OPML_PATH)
 		self.feedsList.Clear()
 		self.choices = []
 		self.filteredItems = []
-		outlines = body.findall("outline")
+		outlines = self.body.findall("outline")
 		for outline in outlines:
 			self.feedsList.Append(outline.get("title"))
 			self.choices.append(outline.get("title"))

--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -178,7 +178,16 @@ class FeedsDialog(wx.Dialog):
 		feedsListGroupContents = wx.BoxSizer(wx.HORIZONTAL)
 		changeFeedsSizer = wx.BoxSizer(wx.VERTICAL)
 
+		body = self._opml._document.getroot().find("body")
+		outlines = sorted(body.findall("outline"), key=lambda el: el.get("title"))
+		for outline in outlines:
+			body.remove(outline)
+			body.append(outline)
+		self._opml._document.write(OPML_PATH)
 		self.choices = [outline.get("title") for outline in self._opml._document.getroot().iter("outline")]
+		self.filteredItems = []
+		for n in range(len(self.choices)):
+			self.filteredItems.append(n)
 		self.feedsList = wx.ListBox(
 			self, choices=self.choices
 		)
@@ -286,29 +295,32 @@ class FeedsDialog(wx.Dialog):
 
 	def onSearchEditTextChange(self, evt):
 		self.feedsList.Clear()
+		self.filteredItems = []
 		# Based on the filter of the Input gestures dialog of NVDA's core.
 		filter = self.searchTextEdit.Value
 		if filter:
 			filter = re.escape(filter)
 			filterReg = re.compile(r"(?=.*?" + r")(?=.*?".join(filter.split(r"\ ")) + r")", re.U | re.IGNORECASE)
-		for choice in self.choices:
+		for index, choice in enumerate(self.choices):
 			if filter and not filterReg.match(choice):
 				continue
+			self.filteredItems.append(index)
 			self.feedsList.Append(choice)
-		try:
+		if len(self.filteredItems) >= 1:
 			self.feedsList.Selection = 0
 			self.onFeedsListChoice(None)
-		except Exception:
+		else:
 			for control in (
 				self.feedsList, self.articlesButton, self.openButton,
-				self.renameButton, self.deleteButton, self.defaultButton
+				self.renameButton, self.deleteButton, self.defaultButton,
+				self.copyButton, self.openButton, self.openHtmlButton
 			):
-				control.disable
+				control.Enabled = False
 
 	def onFeedsListChoice(self, evt):
 		self.feedsList.Enable()
 		self.sel = self.feedsList.Selection
-		self.stringSel = self.feedsList.StringSelection
+		self.stringSel = self.feedsList.GetString(self.sel)
 		self.articlesButton.Enabled = self.sel >= 0
 		self.openButton.Enabled = self.sel >= 0
 		self.openHtmlButton.Enabled = self.sel >= 0
@@ -317,7 +329,7 @@ class FeedsDialog(wx.Dialog):
 		self.defaultButton.Enabled = self.sel >= 0
 
 	def onArticles(self, evt):
-		address = self._opml._document.getroot().findall("./body/outline")[self.sel].get("xmlUrl")
+		address = self._opml._document.getroot().findall("./body/outline")[self.filteredItems[self.sel]].get("xmlUrl")
 		self.feed = Feed(address)
 		self.Disable()
 		try:
@@ -327,17 +339,17 @@ class FeedsDialog(wx.Dialog):
 			raise e
 
 	def onOpen(self, evt):
-		address = self._opml._document.getroot().findall("./body/outline")[self.sel].get("xmlUrl")
+		address = self._opml._document.getroot().findall("./body/outline")[self.filteredItems[self.sel]].get("xmlUrl")
 		os.startfile(address)
 
 	def onOpenHtml(self, evt):
-		address = self._opml._document.getroot().findall("./body/outline")[self.sel].get("xmlUrl")
+		address = self._opml._document.getroot().findall("./body/outline")[self.filteredItems[self.sel]].get("xmlUrl")
 		self.feed = Feed(address)
 		self.feed.buildHtml()
 		os.startfile(os.path.join(HTML_PATH, "feed.html"))
 
 	def onCopy(self, evt):
-		address = self._opml._document.getroot().findall("./body/outline")[self.sel].get("xmlUrl")
+		address = self._opml._document.getroot().findall("./body/outline")[self.filteredItems[self.sel]].get("xmlUrl")
 		if gui.messageBox(
 			# Translators: the label of a message box dialog.
 			_("Do you want to copy feed address to the clipboard\r\n\r\n{feedAddress}?".format(feedAddress=address)),
@@ -358,9 +370,14 @@ class FeedsDialog(wx.Dialog):
 			if d.ShowModal() == wx.ID_CANCEL:
 				self.feedsList.SetFocus()
 				return
-			name = self.createFeed(d.Value)
-			self.feedsList.Append(name)
-			self.feedsList.SetFocus()
+		name = self.createFeed(d.Value)
+		self.feedsList.Append(name)
+		self.choices.append(name)
+		newItem = self.filteredItems[-1] +1
+		self.filteredItems.append(newItem)
+		self.feedsList.Selection = self.feedsList.Count -1
+		self.onFeedsListChoice(None)
+		self.feedsList.SetFocus()
 
 	def onDelete(self, evt):
 		if gui.messageBox(
@@ -372,16 +389,25 @@ class FeedsDialog(wx.Dialog):
 		) == wx.NO:
 			self.feedsList.SetFocus()
 			return
-		element = self._opml._document.getroot().findall("./body/outline")[self.sel]
-		self._opml._document.getroot().find("body").remove(element)
+		body = self._opml._document.getroot().find("body")
+		outline = self._opml._document.getroot().findall("./body/outline")[self.filteredItems[self.sel]]
+		body.remove(outline)
 		self._opml._document.write(OPML_PATH)
-		self.feedsList.Delete(self.sel)
+		del self.choices[self.filteredItems[self.sel]]
+		self.filteredItems = []
+		self.feedsList.Clear()
+		for choice in self.choices:
+			self.feedsList.Append(choice)
+		for n in range(len(self.choices)):
+			self.filteredItems.append(n)
 		self.feedsList.Selection = 0
 		self.onFeedsListChoice(None)
+		from logHandler import log
+		log.info(f"selection: {self.sel}, string: {self.stringSel}, item: {self.filteredItems[self.sel]}")
 		self.feedsList.SetFocus()
 
 	def onDefault(self, evt):
-		url = self._opml._document.getroot().findall(".body/outline")[self.sel].get("xmlUrl")
+		url = self._opml._document.getroot().findall(".body/outline")[self.filteredItems[self.sel]].get("xmlUrl")
 		config.conf["readFeeds"]["defaultUrl"] = url
 		self.onFeedsListChoice(None)
 		self.feedsList.SetFocus()
@@ -397,16 +423,13 @@ class FeedsDialog(wx.Dialog):
 				self.feedsList.SetFocus()
 				return
 			newName = d.Value
-			element = self._opml._document.getroot().findall(".body/outline")[self.sel]
-			element.set("title", newName)
-			element.set("text", newName)
-		body = self._opml._document.getroot().find("body")
-		outlines = sorted(body.findall("outline"), key=lambda el: el.get("title"))
-		for outline in outlines:
-			body.remove(outline)
-			body.append(outline)
+			outline = self._opml._document.getroot().findall(".body/outline")[self.filteredItems[self.sel]]
+			outline.set("title", newName)
+			outline.set("text", newName)
 		self._opml._document.write(OPML_PATH)
 		self.feedsList.SetString(self.sel, newName)
+		self.choices[self.filteredItems[self.sel]] = newName
+		self.onFeedsListChoice(None)
 		self.feedsList.SetFocus()
 
 	def onClose(self, evt):
@@ -435,14 +458,16 @@ class FeedsDialog(wx.Dialog):
 		body = self._opml._document.getroot().find("body")
 		for feed in feeds:
 			body.append(feed)
-		outlines = sorted(body.findall("outline"), key=lambda el: el.get("title"))
-		for outline in outlines:
-			body.remove(outline)
-			body.append(outline)
 		self._opml._document.write(OPML_PATH)
 		self.feedsList.Clear()
+		self.choices = []
+		self.filteredItems = []
+		outlines = body.findall("outline")
 		for outline in outlines:
 			self.feedsList.Append(outline.get("title"))
+			self.choices.append(outline.get("title"))
+		for n in range(len(self.choices)):
+			self.filteredItems.append(n)
 		self.feedsList.Selection = 0
 		self.onFeedsListChoice(None)
 		self.feedsList.SetFocus()
@@ -936,10 +961,6 @@ class Opml(object):
 		element.set("type", "rss")
 		body = self._document.getroot().find("body")
 		body.append(element)
-		outlines = sorted(body.findall("outline"), key=lambda el: el.get("title"))
-		for outline in outlines:
-			body.remove(outline)
-			body.append(outline)
 		self._document.write(self._path)
 
 


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
With the inclusio of OPML support, selected items in the feeds list dialog not always match respective elements in the OPML document. (Reported privately, in particular, issues when using the rename feature).
### Description of how this pull request fixes the issue:
- Update self.choices to represent the list of strings available for the feeds list of the FeedsListDialog.
- self.filteredItems represent the positions of the self.choices really contained in the feeds list.
- Feeds are sorted in the OPML file before creating the feedsList, not when it's opened.
- The position of the feed to manage in the OPML file is calculated taking account filtered items, not just the selected choice in the feedsList.
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
None.