### PR TITLE
Add ability to show articles stimestamps

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -51,6 +51,7 @@ TAG_REGEXP = re.compile('<.*?>')
 confspec = {
 	"defaultUrl": "string(default=http://www.gutenberg.org/cache/epub/feeds/today.rss)",
 	"filterAfterList": "boolean(default=False)",
+	"showArticlesTimestamp": "boolean(default=False)",
 }
 config.conf.spec["readFeeds"] = confspec
 
@@ -485,6 +486,10 @@ class ArticlesDialog(wx.Dialog):
 			TAG_REGEXP, '',
 			parent.feed.getArticleTitle(index)) for index in range(parent.feed.getNumberOfArticles()
 		)]
+		if config.conf["readFeeds"]["showArticlesTimestamp"]:
+			for index, choice in enumerate(articlesChoices):
+				date = parent.feed.getArticleDate(index).split(" +")[0]
+				articlesChoices[index] = f"{choice} - {date}"
 		self.articlesList = sHelper.addLabeledControl(articlesText, wx.ListBox, choices=articlesChoices)
 		self.articlesList.Selection = 0
 		self.articlesList.Bind(wx.EVT_CHOICE, self.onArticlesListChoice)
@@ -546,8 +551,13 @@ class AddonSettingsPanel(SettingsPanel):
 		self.filterAfterList = sHelper.addItem(wx.CheckBox(self, label=_("&Search edit box after feeds list")))
 		self.filterAfterList.SetValue(config.conf["readFeeds"]["filterAfterList"])
 
+		# Translators: label of a dialog.
+		self.showArticlesTimestamp = sHelper.addItem(wx.CheckBox(self, label=_("&Show articles timestamp")))
+		self.showArticlesTimestamp.SetValue(config.conf["readFeeds"]["showArticlesTimestamp"])
+
 	def onSave(self):
 		config.conf["readFeeds"]["filterAfterList"] = self.filterAfterList.GetValue()
+		config.conf["readFeeds"]["showArticlesTimestamp"] = self.showArticlesTimestamp.GetValue()
 
 
 # Feed object
@@ -708,7 +718,7 @@ class Feed(object):
 				date = self._articles[index].find(self.buildTag("updated", self.ns)).text
 			return date
 		except Exception:
-			return None
+			return ""
 
 	def next(self):
 		self._index += 1


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
Closes issue #24 
### Summary of the issue:
Currently there's no option to show timestamps in articles and this may be desired info.
### Description of how this pull request fixes the issue:
In the settings panel for the add-on and configuration spec, an option has been added to show timestamps for articles. getDate method now returns always a string, not None. In the list of articles, the piece of date string after  + has been removed via split method.
### Testing performed:
Tested locally with several feeds.
### Known issues with pull request:
Date is not translated, just presented like it appears in the article.
### Change log entry:
* Added an option to show date of articles.