### PR TITLE
Fix duplicate UI items when reloading add-ons.

### DIFF
--- a/.github/workflows/testWithNVDA.yaml
+++ b/.github/workflows/testWithNVDA.yaml
@@ -45,7 +45,7 @@ jobs:
   
     needs: addon
   
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     

--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -824,7 +824,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def terminate(self):
 		try:
-			self.menu.Remove(self.feedsListItem)
+			self.toolsMenu .Remove(self.feedsListItem)
+		except Exception:
+			pass
+		try:
 			NVDASettingsDialog.categoryClasses.remove(AddonSettingsPanel)
 		except Exception:
 			pass


### PR DESCRIPTION
### Summary of the issue:

When pressing NVDA+ctrl+F3 to reload add-ons:
* the Feeds item in the NVDA -> Tools menu is duplicated
* The Read Feeds settings panel in NVDA settings dialog is duplicated

This is due to a wrong variable name usage for tools menu.
### Description of how this pull request fixes the issue:

* Fixed the variable name 
* Also remove each UI item in a separate try/except block so that if an exception occurs to remove one of the UI element, the other one can be removed anyway.

### Testing performed:

Pressed NVDA+ctrl+F3 and checked that the Feeds menu and the readFeeds panel are not duplicated anymore.

### Known issues with pull request:
None
### Change log entry:
Probably not needed.
