### PR TITLE
Don't use the add-on on secure screens

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -811,6 +811,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	scriptCategory = ADDON_SUMMARY
 
 	def __init__(self):
+		if globalVars.appArgs.secure:
+			return
 		super(GlobalPlugin, self).__init__()
 		NVDASettingsDialog.categoryClasses.append(AddonSettingsPanel)
 		self.toolsMenu = gui.mainFrame.sysTrayIcon.toolsMenu


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
NVDA avoids to open browsers or Windows Explorer on secure screens.
### Description of how this pull request fixes the issue:
Avoid to use the add-on on secure screens, since it's not needed there.
### Testing performed:
Tested setting True and False globalVars.appArgs.secure in the Python console.
### Known issues with pull request:
The add-on won't work on secure screens, what shouldn't have a meaningful impact.
### Change log entry:
* The add-on cannot be used on secure screens.