### PR TITLE
Improve code to disable on secure screens

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 
 # Read feeds: A simple plugin for reading feeds with NVDA
-# Copyright (C) 2012-2021 Noelia Ruiz Martínez, Mesar Hameed
+# Copyright (C) 2012-2022 Noelia Ruiz Martínez, Mesar Hameed
 # Released under GPL 2
 
 import os
@@ -54,6 +54,12 @@ confspec = {
 	"showArticlesDate": "boolean(default=False)",
 }
 config.conf.spec["readFeeds"] = confspec
+
+
+def disableInSecureMode(decoratedCls):
+	if globalVars.appArgs.secure:
+		return globalPluginHandler.GlobalPlugin
+	return decoratedCls
 
 
 def createOpmlPath():
@@ -806,13 +812,12 @@ class Opml(object):
 
 # Global plugin
 
+@disableInSecureMode
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	scriptCategory = ADDON_SUMMARY
 
 	def __init__(self):
-		if globalVars.appArgs.secure:
-			return
 		super(GlobalPlugin, self).__init__()
 		NVDASettingsDialog.categoryClasses.append(AddonSettingsPanel)
 		self.toolsMenu = gui.mainFrame.sysTrayIcon.toolsMenu

--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion": "2019.3.0",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2021.3.1",
+	"addon_lastTestedNVDAVersion": "2021.3.3",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel": None,
 }


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Though implementation made in 13.0.1 suffices for this add-on, let's avoid that any method can be run in secure mode
### Description of how this pull request fixes the issue:
if globalVars.appArgs.secure, use a globalPlugin that does nothing, according to code provided by @CyrilleB79 and @lukaszgo1

See this [topic about disabling add-ons on secure screens](https://nvda-addons.groups.io/g/nvda-addons/message/18181) (last message at this moment).
### Testing performed:
Tested setting globalVars.appArgs.secure to True in the Python console.
### Known issues with pull request:
None
### Change log entry:
None.