### PR TITLE
Don't specify decode when adding feeds

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -606,7 +606,7 @@ class Feed(object):
 			headers = {'User-Agent': userAgent}
 			req = urllib.request.Request(self._url, None, headers)
 			response = urllib.request.urlopen(req)
-		xmlstring = response.read().decode("utf-8").strip()
+		xmlstring = response.read().strip()
 		try:
 			self._document = ElementTree.fromstring(xmlstring)
 		except Exception as e:


### PR DESCRIPTION
## Link to issue number:
None (reported privately)
### Summary of the issue:
This feed cannot be added.
http://feeds.folha.uol.com.br/emcimadahora/rss091.xml

### Description of how this pull request fixes the issue:
.decode("utf-8") has been removed when the feed is read.
### Testing performed:
Tested locally with feeds in different languages.
### Known issues with pull request:
None
### Change log entry:
* Fixed a bug that made impossible to add some feeds.