### PR TITLE
Fixed translatable string issue

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -173,7 +173,7 @@ class FeedsDialog(wx.Dialog):
 		self._opml = Opml(OPML_PATH)
 		super(FeedsDialog, self).__init__(
 			# Translators: Title of a dialog.
-			parent, title=_("Feeds: {}".format(getActiveProfile()))
+			parent, title=_("Feeds: {}").format(getActiveProfile())
 		)
 
 		mainSizer = wx.BoxSizer(wx.VERTICAL)


### PR DESCRIPTION
## Link to issue number:
Fixes #18
Fix-up of #19
### Summary of the issue:
The title of the Feeds window cannot be translated.
#19 was an attempt to fix the issue but a parenthesisis is misplaced.

Unfortunately, I had not reviewed #19 befor nor after it was merged. Sorry.

### Description of how this pull request fixes the issue:
Changed the parenthesis location so that the gettext operates before the string formatting.

### Testing performed:
Checked in French that the title of the dialog is translated.

### Known issues with pull request:
None.

### Change log entry:
Does not deserve a change log entry.
