### PR TITLE
Compatibility with NVDA 2023.1

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion": "2019.3.0",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2022.4.0",
+	"addon_lastTestedNVDAVersion": "2023.1.0",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel": None,
 }

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,10 @@ It contains the following controls:
 * NVDA will display an error message if a new feed cannot be created.
 * The title of the articles list dialog displays the selected feed name and number of items available.
 
+## Changes for 15.0
+
+* Compatible with NVDA 2023.1.
+
 ## Changes for 14.0
 
 * Fixed a bug that made impossible to add some feeds.


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
The add-on needs to be updated to be compatible with NVDA 2023.1.
### Description of how this pull request fixes the issue:
Updated last tested version and readme.
### Testing performed:
Code has been inspected.
### Known issues with pull request:
None
### Change log entry:
* Compatible with NVDA 2023.1.