### PR TITLE
updateFeedParser

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -602,7 +602,7 @@ class Feed(object):
 		try:
 			response = urllib.request.urlopen(self._url)
 		except Exception:
-			userAgent = "UniversalFeedParser/3.3 +http://feedparser.org/"
+			userAgent = "UniversalFeedParser/5.0.1 +http://feedparser.org/"
 			headers = {'User-Agent': userAgent}
 			req = urllib.request.Request(self._url, None, headers)
 			response = urllib.request.urlopen(req)

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,10 @@ It contains the following controls:
 * NVDA will display an error message if a new feed cannot be created.
 * The title of the articles list dialog displays the selected feed name and number of items available.
 
+## Changes for 20.0
+
+* universalFeedParser is updated to 5.0.1, adding support for more feeds.
+
 ## Changes for 15.0
 
 * Compatible with NVDA 2023.1.


### PR DESCRIPTION
- Update universalFeedParser
- Add changes for 20.0

<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None,reported privately
### Summary of the issue:
This feed is not supported:
https://pinecast.com/feed/mosenatlarge

### Description of how this pull request fixes the issue:
Use 5.0.1 version of the universalFeedParser user agent:

https://feedparser.readthedocs.io/en/latest/http-useragent.html

### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
* universalFeedParser is updated to 5.0.1, adding support for more feeds.