### PR TITLE
Use proportion=1 and not 1.0, not supported now

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -202,7 +202,7 @@ class FeedsDialog(wx.Dialog):
 		)
 		self.feedsList.Selection = 0
 		self.feedsList.Bind(wx.EVT_LISTBOX, self.onFeedsListChoice)
-		changeFeedsSizer.Add(self.feedsList, proportion=1.0)
+		changeFeedsSizer.Add(self.feedsList, proportion=1)
 		changeFeedsSizer.AddSpacer(guiHelper.SPACE_BETWEEN_BUTTONS_VERTICAL)
 
 		# Translators: The label of a button to open the list of articles of a feed.


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
NVDA has moved to Python 3.11
### Description of how this pull request fixes the issue:
- Use xml from Python 3.11.

### Testing performed:
Needs to be tested locally.
### Known issues with pull request:
None
### Change log entry:
None