### PR TITLE
Add compatibility with NVDA 2024.1

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -172,7 +172,7 @@ class FeedsDialog(wx.Dialog):
 			return
 		FeedsDialog._instance = self
 		self._opml = Opml(OPML_PATH)
-		super(FeedsDialog, self).__init__(
+		super().__init__(
 			# Translators: Title of a dialog.
 			parent, title=_("Feeds: {}").format(getActiveProfile())
 		)
@@ -482,7 +482,7 @@ class ArticlesDialog(wx.Dialog):
 
 	def __init__(self, parent):
 		# Translators: The title of the articles dialog.
-		super(ArticlesDialog, self).__init__(parent, title="{feedTitle} ({feedNumber})".format(
+		super().__init__(parent, title="{feedTitle} ({feedNumber})".format(
 			feedTitle=parent.stringSel, feedNumber=parent.feed.getNumberOfArticles()
 		))
 
@@ -529,7 +529,6 @@ class ArticlesDialog(wx.Dialog):
 		mainSizer.Add(buttonHelper.sizer)
 		mainSizer.Add(sHelper.sizer, border=guiHelper.BORDER_FOR_DIALOGS, flag=wx.ALL)
 		mainSizer.Fit(self)
-		self.Sizer = mainSizer
 		self.CentreOnScreen()
 
 	def onArticlesListChoice(self, evt):

--- a/buildVars.py
+++ b/buildVars.py
@@ -27,7 +27,7 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3")
-	"addon_minimumNVDAVersion": "2023.2.0",
+	"addon_minimumNVDAVersion": "2024.1.0",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
 	"addon_lastTestedNVDAVersion": "2024.1.0",
 	# Add-on update channel (default is stable or None)


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
The add-on needs to be compatible with NVDA 2024.1.
### Description of how this pull request fixes the issue:
- Use xml from Python 3.11.
- Remove self.sizer = mainSizer from the ArticlesDialog, suggested by @beqabeqa473, needed to show the dialog.
- Simplify call to super().
### Testing performed:
Tested locally, as mentioned in

https://github.com/nvaccess/nvda/issues/15770

### Known issues with pull request:
None
### Change log entry:
None