### PR TITLE
Use / as the last character of googleUrl

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -678,7 +678,7 @@ class Feed(object):
 			index = self._index
 		description = None
 		try:
-			if self.getFeedUrl().startswith("https://www.google.com") and "/alerts/" in self.getFeedUrl():
+			if self.getFeedUrl().startswith("https://www.google.com/") and "/alerts/" in self.getFeedUrl():
 				description = self._articles[index].find(self.buildTag("content", self.ns)).text
 			if description is not None:
 				return description


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
https://google.com should end with /
### Description of how this pull request fixes the issue:
Ends url with a /
### Testing performed:
None yet
### Known issues with pull request:
None
### Change log entry:
None