### PR TITLE
Add support for CBC feeds

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -65,6 +65,7 @@ userAgents = {
 	"www.cbc.ca": "Bloglines/3.1 (http://www.bloglines.com)",
 }
 
+
 def disableInSecureMode(decoratedCls):
 	if globalVars.appArgs.secure:
 		return globalPluginHandler.GlobalPlugin

--- a/buildVars.py
+++ b/buildVars.py
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion": "2024.1.0",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2024.3.0",
+	"addon_lastTestedNVDAVersion": "2024.4",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel": None,
 }


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None. Reported privately.
### Summary of the issue:
Feedslike https://www.cbc.ca/cmlink/rss-canada-britishcolumbia aren't supported.
### Description of how this pull request fixes the issue:
- Added an userAgents dictionary to store the more appropriate user agent to handle different cases. Bloglines is used for the mentioned feed.
- Used universalFeedParser as the default option, and urllib to handle possible exceptions.
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
- Added support for CBC feeds.