### PR TITLE
Add support for rss.cbc.ca feeds

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -63,6 +63,7 @@ config.conf.spec["readFeeds"] = confspec
 
 userAgents = {
 	"www.cbc.ca": "Bloglines/3.1 (http://www.bloglines.com)",
+	"rss.cbc.ca": "Bloglines/3.1 (http://www.bloglines.com)",
 }
 
 


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None. Reported privately.
### Summary of the issue:
rss.cbc.ca aren't supported.
### Description of how this pull request fixes the issue:
Added bloglines as the user agent for these feeds.
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
None. Fixup of PR #52