### PR TITLE
Fix translatable messages

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -558,6 +558,7 @@ class ArticlesDialog(wx.Dialog):
 			_("Article information"),
 			wx.YES | wx.NO | wx.CANCEL | wx.ICON_QUESTION
 		) == wx.YES:
+			articleInfo = f"{title}\n{address}\n"
 			api.copyToClip(articleInfo)
 
 	def onClose(self, evt):

--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -546,7 +546,7 @@ class ArticlesDialog(wx.Dialog):
 		os.startfile(self.Parent.feed.getArticleLink(self.articlesList.Selection))
 
 	def onArticlesListInfo(self, evt):
-		title=self.articlesList.StringSelection
+		title = self.articlesList.StringSelection
 		address = self.Parent.feed.getArticleLink(self.articlesList.Selection)
 		if gui.messageBox(
 			_(

--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -365,8 +365,11 @@ class FeedsDialog(wx.Dialog):
 	def onCopy(self, evt):
 		address = self.body.findall("outline")[self.filteredItems[self.sel]].get("xmlUrl")
 		if gui.messageBox(
-			# Translators: the label of a message box dialog.
-			_("Do you want to copy feed address to the clipboard\r\n\r\n{feedAddress}?".format(feedAddress=address)),
+			_(
+				# Translators: the label of a message box dialog.
+				"Do you want to copy feed address to the clipboard?"
+				"\n{}"
+			).format({address}),
 			# Translators: the title of a message box dialog.
 			_("Copy feed address"),
 			wx.YES | wx.NO | wx.CANCEL | wx.ICON_QUESTION
@@ -543,13 +546,14 @@ class ArticlesDialog(wx.Dialog):
 		os.startfile(self.Parent.feed.getArticleLink(self.articlesList.Selection))
 
 	def onArticlesListInfo(self, evt):
-		articleInfo = "{title}\r\n\r\n{address}".format(
-			title=self.articlesList.StringSelection,
-			address=self.Parent.feed.getArticleLink(self.articlesList.Selection)
-		)
+		title=self.articlesList.StringSelection
+		address = self.Parent.feed.getArticleLink(self.articlesList.Selection)
 		if gui.messageBox(
-			# Translators: the label of a message box dialog.
-			_("%sDo you want to copy article title and link to the clipboard?" % (articleInfo + "\r\n\r\n")),
+			_(
+				# Translators: the label of a message box dialog.
+				"{}\n{}\n"
+				"Do you want to copy article title and link to the clipboard?"
+			).format(title, address),
 			# Translators: the title of a message box dialog.
 			_("Article information"),
 			wx.YES | wx.NO | wx.CANCEL | wx.ICON_QUESTION


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None. See

https://nvdaes.groups.io/g/lista/message/5384
### Summary of the issue:
Some messages couldn't be translated.
### Description of how this pull request fixes the issue:
Changed the syntax to format messages.
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
None. Translations Will be updated.