### PR TITLE
Improve notifications when article or URL are copied

### DIFF
--- a/addon/globalPlugins/readFeeds/__init__.py
+++ b/addon/globalPlugins/readFeeds/__init__.py
@@ -374,7 +374,7 @@ class FeedsDialog(wx.Dialog):
 			_("Copy feed address"),
 			wx.YES | wx.NO | wx.CANCEL | wx.ICON_QUESTION
 		) == wx.YES:
-			api.copyToClip(address)
+			core.callLater(50, api.copyToClip, address, True)
 
 	def onNew(self, evt):
 		# Translators: The label of a field to enter an address for a new feed.
@@ -559,7 +559,7 @@ class ArticlesDialog(wx.Dialog):
 			wx.YES | wx.NO | wx.CANCEL | wx.ICON_QUESTION
 		) == wx.YES:
 			articleInfo = f"{title}\n{address}\n"
-			api.copyToClip(articleInfo)
+			core.callLater(50, api.copyToClip, articleInfo, True)
 
 	def onClose(self, evt):
 		self.Parent.Enable()
@@ -943,10 +943,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			title=re.sub(TAG_REGEXP, '', self.feed.getArticleTitle()),
 			address=self.feed.getArticleLink()
 		)
-		if scriptHandler.getLastScriptRepeatCount() == 1 and api.copyToClip(articleInfo):
-			# Translators: message presented when the information about an article of a feed
-			# is copied to the clipboard.
-			ui.message(_("Copied to clipboard %s") % articleInfo)
+		if scriptHandler.getLastScriptRepeatCount() == 1:
+			api.copyToClip(articleInfo, True)
 		else:
 			ui.message(articleInfo)
 
@@ -997,7 +995,4 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			title=re.sub(TAG_REGEXP, '', self.feed.getArticleTitle()),
 			address=self.feed.getArticleLink()
 		)
-		if api.copyToClip(articleInfo):
-			# Translators: message presented when the information about an article of a feed
-			# is copied to the clipboard.
-			ui.message(_("Copied to clipboard %s") % articleInfo)
+		api.copyToClip(articleInfo, True)

--- a/buildVars.py
+++ b/buildVars.py
@@ -27,7 +27,7 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3")
-	"addon_minimumNVDAVersion": "2024.1.0",
+	"addon_minimumNVDAVersion": "2024.4.1",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
 	"addon_lastTestedNVDAVersion": "2024.4",
 	# Add-on update channel (default is stable or None)

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,10 @@ It contains the following controls:
 * NVDA will display an error message if a new feed cannot be created.
 * The title of the articles list dialog displays the selected feed name and number of items available.
 
+## Changes for 39.0.0
+
+* Improved notifications when title or URL are copied.
+
 ## Changes for 34.0.0
 
 * Added support for rss.cbc.ca feeds.


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None

https://nvdaes.groups.io/g/lista/topic/110153430
### Summary of the issue:
When the feed address or feed info are copied, this is not announced.
### Description of how this pull request fixes the issue:
Used callLater to call the api.copyToClip function with True as second parameter.
### Testing performed:
Tested locally.
### Known issues with pull request:
None.
### Change log entry:
* Improved notifications when article or URL are copied.